### PR TITLE
docs(README): adjust the usage example to the latest version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # fints-institute-db
+
 [![CI](https://github.com/svenstaro/fints-institute-db/workflows/CI/badge.svg)](https://github.com/svenstaro/fints-institute-db/actions)
 [![Crates.io](https://img.shields.io/crates/v/fints-institute-db.svg)](https://crates.io/crates/fints-institute-db)
 [![docs](https://docs.rs/fints-institute-db/badge.svg)](https://docs.rs/fints-institute-db)
@@ -12,45 +13,52 @@ During the build it will download a CSV file with all the banks which it will th
 
 Put this into your `Cargo.toml`:
 
-    [dependencies]
-    fints_institute_db = "1"
+```toml
+[dependencies]
+fints-institute-db = "1.0"
+```
 
 Then to use it:
 
 ```rust
 use fints_institute_db::get_bank_by_bank_code;
 
-let bank = get_bank_by_bank_code("12070000");
-println!("{:?}", bank.pin_tan_url);
+if let Some(bank) = get_bank_by_bank_code("12070000") {
+    println!("{:?}", bank.pin_tan_address);
+}
 ```
 
 ## Command line utility
 
 Additionally this crate includes a CLI tool for your convenience:
 
-    fints-institute-db 1.0.6
-    Sven-Hendrik Haase <svenstaro@gmail.com>
-    Tool to query the FinTS database.
+```sh
+fints-institute-db 1.0.6
+Sven-Hendrik Haase <svenstaro@gmail.com>
+Tool to query the FinTS database.
 
-    By default it will return just the FinTS URL for the first matching bank.
+By default it will return just the FinTS URL for the first matching bank.
 
-    USAGE:
-        cli [FLAGS] [OPTIONS] <--iban <iban>|--bankcode <bank_code>>
+USAGE:
+    cli [FLAGS] [OPTIONS] <--iban <iban>|--bankcode <bank_code>>
 
-    FLAGS:
-        -h, --help       Prints help information
-        -j, --json       Change tool behavior to output all data for the record as JSON
-        -V, --version    Prints version information
+FLAGS:
+    -h, --help       Prints help information
+    -j, --json       Change tool behavior to output all data for the record as JSON
+    -V, --version    Prints version information
 
-    OPTIONS:
-        -b, --bankcode <bank_code>    Look up bank by German bank code (format: 12030000)
-        -i, --iban <iban>             Look up bank by IBAN (format: DE02120300000000202051)
+OPTIONS:
+    -b, --bankcode <bank_code>    Look up bank by German bank code (format: 12030000)
+    -i, --iban <iban>             Look up bank by IBAN (format: DE02120300000000202051)
+```
 
 Example usages:
 
-    cargo run -- -b 12030000
+```sh
+cargo run -- -b 12030000
 
-    cargo run -- -i DE02120300000000202051
+cargo run -- -i DE02120300000000202051
+```
 
 This crate is inspired by https://github.com/jhermsmeier/fints-institute-db and https://github.com/dr-duplo/python-fints-url
 


### PR DESCRIPTION
This PR fixes the usage examples in the `README.md` that seemed to be not more valid.

Additionally, I adjust the Markdown formatting, to the typical formatting for shell code etc.