### PR TITLE
Update iban_validate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "iban_validate"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1d358f7ae89819e8656f1b495c9d760a9ca315998b12d589dc516c9f81ed08"
+checksum = "068867e6604f60f62b2e3b12cc90501a45ff66bfc91239d72ec420528dfc388d"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["fints", "hbci", "bank", "banks", "banking"]
 categories = ["command-line-utilities", "command-line-interface", "parsing"]
 
 [workspace.dependencies]
-iban_validate = "4"
+iban_validate = "5"
 serde_json = "1"
 
 [profile.release]


### PR DESCRIPTION
I updated the `iban_validate` crate, this PR updates it to the latest version. It updates the registry and is technically breaking since it now uses `Error` from `core` and removes the `std` feature. See the [changelog](https://github.com/ThomasdenH/iban_validate/blob/master/CHANGELOG.md) for all changes.